### PR TITLE
Updated rebar.config to indicate support for R15

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -1,4 +1,4 @@
-{require_otp_vsn, "R13B04|R14"}.
+{require_otp_vsn, "R13B04|R14|R15"}.
 
 {erl_opts, [debug_info, warn_unused_vars, warn_shadow_vars, warn_unused_import]}.
 {port_sources, ["c_src/*.cc", 


### PR DESCRIPTION
Hi guys,

Snappy works okay in R15 and R15B for both compressing and decompressing data from outside applications (i.e. data coming from Python and Ruby). I'm not sure if there are any specific tests that I need to do?

Tested on Archlinux and Fedora 11.

Cheers,

Pete
