### PR TITLE
Fix build for R16

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -1,4 +1,4 @@
-{require_otp_vsn, "R13B04|R14|R15"}.
+{require_otp_vsn, "R13B04|R14|R15|R16"}.
 
 {erl_opts, [debug_info, warn_unused_vars, warn_shadow_vars, warn_unused_import]}.
 {port_env, [


### PR DESCRIPTION
This patch adds the R16 Erlang release as a supported version for snappy-erlang-nif.
