### PR TITLE
Improve build on Mac

### DIFF
--- a/c_src/Makefile
+++ b/c_src/Makefile
@@ -17,9 +17,9 @@ C_SRC_OUTPUT ?= $(CURDIR)/../priv/$(PROJECT).so
 UNAME_SYS := $(shell uname -s)
 ifeq ($(UNAME_SYS), Darwin)
 	CC ?= cc
-	CFLAGS ?= -O3 -std=c99 -arch x86_64 -finline-functions -Wall -Wmissing-prototypes
-	CXXFLAGS ?= -O3 -arch x86_64 -finline-functions -Wall
-	LDFLAGS ?= -arch x86_64 -flat_namespace -undefined suppress
+	CFLAGS += -O3 -std=c99 -arch x86_64 -finline-functions -Wall -Wmissing-prototypes
+	CXXFLAGS += -O3 -arch x86_64 -finline-functions -Wall
+	LDFLAGS += -arch x86_64 -flat_namespace -undefined suppress
 else ifeq ($(UNAME_SYS), FreeBSD)
 	CC ?= cc
 	CFLAGS ?= -O3 -std=c99 -finline-functions -Wall -Wmissing-prototypes


### PR DESCRIPTION
Mac users (who use MacPorts) decide to export some additional include and linker paths via `CFLAGS` and `LDFLAGS` (e.g. `/opt/local/lib`). They override default flags provided in Makefile, including essential one that suppresses undefined function errors.

This PR changes the default behaviour to append these flags, instead of dropping them when env. var. is already set.