### PR TITLE
tidy up NIF loader

### DIFF
--- a/src/snappy.erl
+++ b/src/snappy.erl
@@ -33,11 +33,7 @@ init() ->
     Dir ->
         filename:join(Dir, "snappy_nif")
     end,
-    (catch erlang:load_nif(SoName, 0)),
-    case erlang:system_info(otp_release) of
-    "R13B03" -> true;
-    _ -> ok
-    end.
+    erlang:load_nif(SoName, 0).
 
 
 compress(_IoList) ->


### PR DESCRIPTION
There's no need to try/catch nif loader anymore as R13B is long since gone and all

- closes #19

@arcusfelis I assume this is OK for you too? if you are all good at MongooseIM end I suggest we tag this so you're not running from a random master commit. I could publish to hex if thats useful, but I've not done this prior for an erlang module. tips welcomed.