### PR TITLE
c_src: handle catch cleanly

### DIFF
--- a/c_src/snappy_nif.cc
+++ b/c_src/snappy_nif.cc
@@ -158,7 +158,7 @@ snappy_compress_erl(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])
         SnappyNifSink sink(env);
         snappy::Compress(&source, &sink);
         return make_ok(env, enif_make_binary(env, &sink.getBin()));
-    } catch(std::bad_alloc e) {
+    } catch(const std::bad_alloc & e) {
         return make_error(env, "insufficient_memory");
     } catch(...) {
         return make_error(env, "unknown");


### PR DESCRIPTION
- see https://github.com/skunkwerks/snappy-erlang-nif/issues/24
- thanks @dcb314 for the patch